### PR TITLE
docs: add Mermaid architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ print(f"Risk Level: {metrics.risk_level.value}")
 pnl = rm.close_position("AAPL")
 ```
 
+### Arquitetura
+
+```mermaid
+graph TD
+    A["portfolio_risk_demo.py"] -->|cria| B["RiskManager"]
+    B --> C["Position (dataclass)"]
+    B --> D["RiskMetrics (dataclass)"]
+    D --> E["VaR 95%/99%<br/>Expected Shortfall"]
+    D --> F["Max Drawdown<br/>Sharpe Ratio"]
+    D --> G["Nivel de Risco<br/>LOW/MED/HIGH/CRITICAL"]
+    B --> H["Curva de Equity"]
+    B --> I["Verificacao Stop-Loss"]
+    B --> J["Position Sizing"]
+```
+
 ### Estrutura do Projeto
 
 ```
@@ -179,6 +194,21 @@ print(f"Risk Level: {metrics.risk_level.value}")
 
 # Close position
 pnl = rm.close_position("AAPL")
+```
+
+### Architecture
+
+```mermaid
+graph TD
+    A["portfolio_risk_demo.py"] -->|creates| B["RiskManager"]
+    B --> C["Position (dataclass)"]
+    B --> D["RiskMetrics (dataclass)"]
+    D --> E["VaR 95%/99%<br/>Expected Shortfall"]
+    D --> F["Max Drawdown<br/>Sharpe Ratio"]
+    D --> G["Risk Level<br/>LOW/MED/HIGH/CRITICAL"]
+    B --> H["Equity Curve"]
+    B --> I["Stop-Loss Check"]
+    B --> J["Position Sizing"]
 ```
 
 ### Project Structure


### PR DESCRIPTION
### **User description**
Add Mermaid flowcharts showing RiskManager components in both PT-BR and EN sections.


___

### **PR Type**
Documentation


___

### **Description**
- Add Mermaid architecture diagram to Portuguese section

- Add Mermaid architecture diagram to English section

- Diagrams show RiskManager components and data flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  README["README.md"]
  README -->|adds PT-BR| ARCH_PT["Arquitetura section"]
  README -->|adds EN| ARCH_EN["Architecture section"]
  ARCH_PT -->|contains| MERMAID_PT["Mermaid diagram PT"]
  ARCH_EN -->|contains| MERMAID_EN["Mermaid diagram EN"]
  MERMAID_PT -->|shows| COMPONENTS["RiskManager components"]
  MERMAID_EN -->|shows| COMPONENTS
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add architecture diagrams in both languages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added "Arquitetura" section with Mermaid diagram showing RiskManager <br>architecture in Portuguese<br> <li> Added "Architecture" section with Mermaid diagram showing RiskManager <br>architecture in English<br> <li> Both diagrams illustrate the relationship between <br><code>portfolio_risk_demo.py</code>, <code>RiskManager</code>, <code>Position</code>, <code>RiskMetrics</code>, and key <br>features like VaR, Expected Shortfall, Max Drawdown, Sharpe Ratio, <br>Equity Curve, Stop-Loss Check, and Position Sizing</ul>


</details>


  </td>
  <td><a href="https://github.com/galafis/risk-management-system/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime, API, or behavior impact; only risk is Mermaid rendering differences across Markdown viewers.
> 
> **Overview**
> Adds Mermaid **architecture diagrams** to `README.md` in both the Portuguese and English sections, illustrating how `portfolio_risk_demo.py` uses `RiskManager` and how core concepts (positions, risk metrics, equity curve, stop-loss, position sizing) relate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18fac04502c7f727c73911679d6fe269d11ccc77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->